### PR TITLE
Update MethodInfoPointer.cs : fixed a bug

### DIFF
--- a/Source/LimnorDesigner/MethodBuilder/MethodInfoPointer.cs
+++ b/Source/LimnorDesigner/MethodBuilder/MethodInfoPointer.cs
@@ -37,6 +37,9 @@ namespace LimnorDesigner.MethodBuilder
 {
 	public class MethodInfoPointer : MethodPointer, IMethodMeta
 	{
+	
+	        private bool isArrayType;
+		
 		private MethodInfo _mif;
 		private bool _isWebServerMethod;
 		//
@@ -262,6 +265,11 @@ namespace LimnorDesigner.MethodBuilder
 			if (b)
 			{
 				CodeArrayIndexerExpression ai = new CodeArrayIndexerExpression(OnGetTargetObject(targetObject), ParameterCodeExpressions);
+				return ai;
+			}
+			else if (isArrayType)
+			{
+				CodeArrayIndexerExpression ai = new CodeArrayIndexerExpression(OnGetTargetObject(targetObject), ParameterCodeExpressions[0]);
 				return ai;
 			}
 			else
@@ -725,6 +733,17 @@ namespace LimnorDesigner.MethodBuilder
 							ps = new CodeExpression[] { };
 						}
 						SetParameterExpressions(ps);
+						
+						isArrayType = string.Compare(mif.Name, "set_Item", StringComparison.Ordinal) == 0;
+						isArrayType = isArrayType && mif.IsSpecialName;
+						if (isArrayType)
+						{
+							CodeExpression tarobj = GetReferenceCode(methodToCompile, statements, false);
+							CodeAssignStatement cas00 = new CodeAssignStatement(tarobj, ps[1]);
+							statements.Add(cas00);
+							return;
+						}
+						
 						cmi = GetReferenceCode(methodToCompile, statements, false);
 					}
 				}


### PR DESCRIPTION
I fixed a bug in the program where the Limnor Compiler was writing a wrong code for set_Item method.

Scenario:
Suppose I create an object of System.Collections.Specialized.StringCollection and use this object to access set_Item(int index, string value ) method and let's say I set the index 5 and the value "Hello" and name the object as colec, the Limnor Compiler generates the code as:
colec.set_Item(5, "Hello");
which generates C# compiler error CS0571 : cannot explicitly call an operator or accessor.

The correct one should be like this:
colec[5] = "hello";
and the modified one generates this code by checking,
if the method name is exactly "set_Item" and also if IsSpecialName property is true.

Have a nice day!!!